### PR TITLE
add namespace explicitly to kubectl

### DIFF
--- a/config/prow/Makefile
+++ b/config/prow/Makefile
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 update-config:
-	kubectl create configmap config --from-file=config.yaml=config.yaml --dry-run -o yaml | kubectl replace configmap config -f -
+	kubectl -n default create configmap config --from-file=config.yaml=config.yaml --dry-run -o yaml | kubectl -n default replace configmap config -f -
 
 update-plugins:
-	kubectl create configmap plugins --from-file=plugins.yaml=plugins.yaml --dry-run -o yaml | kubectl replace configmap plugins -f -
+	kubectl -n default create configmap plugins --from-file=plugins.yaml=plugins.yaml --dry-run -o yaml | kubectl -n default replace configmap plugins -f -
 
 deploy:
-	kubectl apply -f cluster/ --prune -l app.kubernetes.io/part-of=prow 
+	kubectl -n default apply -f cluster/ --prune -l app.kubernetes.io/part-of=prow 
 
 update-job-config:
 	./update-job-config.sh ../jobs/

--- a/config/prow/update-job-config.sh
+++ b/config/prow/update-job-config.sh
@@ -26,6 +26,6 @@ fi
 find "${JOB_CONFIG_PATH}" -name "*.yaml" | \
     xargs -n1 -I {} sh -c 'echo --from-file=$(basename {})={}' | \
     tr '\n' ' ' | \
-    cat <(echo -n "kubectl create cm job-config --dry-run -o yaml ") - | \
+    cat <(echo -n "kubectl -n default create cm job-config --dry-run -o yaml ") - | \
     sh | \
-    kubectl replace -f - 
+    kubectl -n default replace -f - 


### PR DESCRIPTION
Our postsubmit job runs under namespace `test-pods`, so we need to add namespace explicitly.