### PR TITLE
fix secrets projected volume readonly error

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -144,5 +144,6 @@ presets:
     secret:
       secretName: docker
   volumeMounts:
-  - mountPath: /home/.docker/
+  - mountPath: /home/.docker/config
+    subPath: config
     name: docker-credential


### PR DESCRIPTION
Our periodic image building has these errors, that's because docker secret projected as read-only directory
```
+ PLATFORMS=linux/amd64,linux/arm64
+ docker buildx build --platform linux/amd64,linux/arm64 --push -f build/ks-apiserver/Dockerfile -t kubesphere/ks-apiserver:latest .
error: mkdir /home/.docker/buildx: read-only file system
```
This PR fix it by using `subPath`