### PR TITLE
token throttled due to large number of repos under org, sync only selected repos

### DIFF
--- a/config/jobs/kubesphere/test-infra/test-infra-postsubmits.yaml
+++ b/config/jobs/kubesphere/test-infra/test-infra-postsubmits.yaml
@@ -68,11 +68,11 @@ periodics:
       args:
       - --config=/etc/config/labels.yaml
       - --confirm=true
-      - --orgs=kubesphere,kubesphere-sigs
       - --token=/etc/github/oauth
       - --endpoint=http://ghproxy.default.svc.cluster.local
       - --endpoint=https://api.github.com
       - --debug
+      - --only=kubesphere/kubesphere,kubesphere/console,kubesphere/ks-installer,kubesphere/kubekey,kubesphere/website,kubesphere/community,kubesphere/devops-agent
       volumeMounts:
       - name: oauth
         mountPath: /etc/github


### PR DESCRIPTION
Label sync job keeps failing due to the token being throttled. So only sync labels to selected repos.

```
{"component":"label_sync","file":"label_sync/main.go:615","func":"main.RepoUpdates.DoUpdates.func1","level":"debug","msg":"running update","org":"kubesphere","repo":"jenkins-library","severity":"debug","time":"2021-08-11T00:39:28Z","why":"missing"}
{"client":"github","component":"label_sync","file":"prow/github/client.go:784","func":"k8s.io/test-infra/prow/github.(*client).log","level":"info","msg":"AddRepoLabel(kubesphere, jenkins-library, tide/merge-method-rebase, Denotes a PR that should be rebased by tide when it merges., ffaa00)","severity":"info","time":"2021-08-11T00:39:28Z"}
{"client":"github","component":"label_sync","file":"prow/github/client.go:414","func":"k8s.io/test-infra/prow/github.(*throttler).Wait.func1","level":"debug","msg":"Throttled clientside for more than a minute","severity":"debug","throttle-duration":"3m59.682533459s","throttled":true,"time":"2021-08-11T00:39:39Z"}
{"cache-mode":"","client":"github","component":"label_sync","file":"prow/github/client.go:497","func":"k8s.io/test-infra/prow/github.
```