### PR TITLE
add kind prefix to ui_text_review label

### DIFF
--- a/config/prow/labels.yaml
+++ b/config/prow/labels.yaml
@@ -384,7 +384,7 @@ repos:
         addedBy: anyone
       - color: e11d21
         description: Indicates that the UI text needs to be reviewed by the technical writing team.
-        name: require-ui-text-review
+        name: kind/require-ui-text-review
         target: both
         prowPlugin: label
         addedBy: anyone
@@ -392,7 +392,7 @@ repos:
     labels:
       - color: e11d21
         description: Indicates that the UI text needs to be reviewed by the technical writing team.
-        name: require-ui-text-review
+        name: kind/require-ui-text-review
         target: both
         prowPlugin: label
         addedBy: anyone


### PR DESCRIPTION
`require-ui-text-review` is a standalone label, which is not recognized by prow. Add kind/ prefix.