### PR TITLE
Add additional_labels for label plugin

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -44,6 +44,13 @@ size:
   xl:  500
   xxl: 1000
 
+label:
+  additional_labels:
+    # These labels are used to make Tide merge with a non-default merge method
+    - tide/merge-method-merge
+    - tide/merge-method-rebase
+    - tide/merge-method-squash
+
 repo_milestone:
   '':
     maintainers_id: 4979590


### PR DESCRIPTION
### What dose this PR?

Add additional labels for label plugin:

- tide/merge-method-merge
- tide/merge-method-rebase
- tide/merge-method-squash

Those labels are used to make Tide merge with a non-default merge method. This approach is from [here](https://github.com/kubernetes/test-infra/blob/9d274424e5030fcf1ec8252b066b59d4a7fdf660/config/prow/plugins.yaml#L121-L133).

### Why do we need it?

Some contributors might submit two or more commits which might be useless into one pull request, like below:

![image](https://user-images.githubusercontent.com/16865714/141965608-f397cb17-e674-440e-aa93-2f7aed86fa60.png)

By default, prow will make all commits into target branch whether they make sense or not, please see:

![image](https://user-images.githubusercontent.com/16865714/141965512-cdda1bdf-7af5-4f01-9565-002e1db55987.png)

If we support to label `tide/merge-method-squash`, prow will automatically squash and merge the pull request, please see [the example](https://github.com/kubernetes/test-infra/pull/24235#issuecomment-965333190).

/kind feature
/cc @kubesphere/ci 
