### PR TITLE
Make default merge_method of kubesphere/ks-devops be squash

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -70,6 +70,7 @@ tide:
     kubesphere/s2irun: squash
     kubesphere/community: squash
     kubesphere/ks-jenkins: squash
+    kubesphere/ks-devops: squash
     kubesphere/prow-tutorial: squash
   target_url: https://prow.kubesphere.io
   queries:


### PR DESCRIPTION
### What this PR dose / Why we need it

Make default `merge_method` of [kubesphere/ks-devops](https://github.com/kubesphere/ks-devops) be `squash`.

`Squash and merge` method is clearer than merging directly, please see the commit history:

![image](https://user-images.githubusercontent.com/16865714/148923978-e7a81423-35e6-40be-8ad8-ef7a644a69d2.png)
