### PR TITLE
Enable Prow configuration update automatically

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -146,6 +146,9 @@ plugins:
     - milestonestatus
     - release-note
     - require-matching-label
+  kubesphere/test-infra:
+    plugins:
+      - config-updater
 
 external_plugins:
   kubesphere:


### PR DESCRIPTION
### What this PR does

Config `config-updater` plugin for `kubesphere/test-infra` repository to enable Prow configuration update automatically.

### Why we need it?

After we change `config/prow/config.yaml` and `config/prow/plugins.yaml`(you can see https://github.com/kubesphere/test-infra/pull/50), there is no feedback of config update from `ks-ci-bot`. Expected response is like below:

![image](https://user-images.githubusercontent.com/16865714/163783038-919403ba-54b3-403b-a69e-30abdf819d45.png)


See https://github.com/kubernetes/test-infra/blob/2d32ed803286395c6fe84e46855225e82ea6ccad/prow/plugins/updateconfig/README.md for more details about `config-updater` plugin.

/cc @kubesphere/sig-infra 