### PR TITLE
Make default merge_method of kubesphere/console be squash

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -66,6 +66,7 @@ tide:
   rebase_label: tide/merge-method-rebase
   merge_label: tide/merge-method-merge
   merge_method:
+    kubesphere/console: squash
     kubesphere/s2ioperator: squash
     kubesphere/s2irun: squash
     kubesphere/community: squash


### PR DESCRIPTION
### What this PR dose / Why we need it

Make default `merge_method` of [kubesphere/console](https://github.com/kubesphere/console) be `squash`.

`Squash and merge` method is clearer than merging directly,