### PR TITLE
skip build image when update branch l10n_master

### DIFF
--- a/config/jobs/kubesphere/console/console-postsubmits.yaml
+++ b/config/jobs/kubesphere/console/console-postsubmits.yaml
@@ -5,12 +5,13 @@ postsubmits:
       preset-docker-sock: "true"
       preset-docker-credentials: "true"
       preset-docker-multiarch: "true"
-    always_run: false
-    skip_if_only_changed: "^locales/"
+    always_run: true
     branches:
     - ^master$
     - release-*
     - v*
+    skip_branches:
+    - l10n_master
     decorate: true
     spec:
       containers:


### PR DESCRIPTION
## What this PR does / why we need it:
skip build image when update branch l10n_master

Crowdin will submit a large number of commit to branch `l10n_master` , and each submission will trigger a build task, resulting in a large waste of resources of the build platform.

such as https://github.com/kubesphere/console/pull/3402
![image](https://user-images.githubusercontent.com/22290449/174769519-5da26d53-ec09-4480-aabe-cfaebee398e5.png)

![image](https://user-images.githubusercontent.com/22290449/174769596-f33668d2-aafd-4e83-9ada-b7e9c35f81b0.png)




Signed-off-by: pixiake <guofeng@yunify.com>

