### PR TITLE
Change the default merge method to squash for kubesphere/kubesphere

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -66,6 +66,7 @@ tide:
   rebase_label: tide/merge-method-rebase
   merge_label: tide/merge-method-merge
   merge_method:
+    kubesphere/kubesphere: squash
     kubesphere/console: squash
     kubesphere/s2ioperator: squash
     kubesphere/s2irun: squash


### PR DESCRIPTION
Change the default merge method to squash for kubesphere/kubesphere.